### PR TITLE
experimental sixel support

### DIFF
--- a/backends/fb.c
+++ b/backends/fb.c
@@ -713,8 +713,11 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
     size_t sixel_src_y = ctx->sixel_start_y;
     size_t sixel_dest_y = 0;
 
+    bool last = false;
+
     switch (sixel_src_y) {
         case 0:
+            last = true;
             sixel_src_y = 1;
             sixel_dest_y = 0;
             break;
@@ -728,6 +731,9 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
     }
 
     size_t sixel_end_y = ctx->sixel_end_y ? ctx->sixel_end_y-- : 0;
+    if (sixel_end_y == 1 && last)
+        goto clear;
+
     if (!sixel_end_y || sixel_src_y >= sixel_end_y) {
         return;
     }
@@ -741,6 +747,7 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
         }
     }
 
+clear:
     for (size_t cy = 0; cy < ctx->glyph_height; cy++) {
         size_t offset = cy * ctx->width;
         memset(ctx->sixel_canvas + (sixel_end_y - 1) * ctx->glyph_height * ctx->width + offset + ctx->sixel_start_x * ctx->glyph_width, 0,

--- a/backends/fb.c
+++ b/backends/fb.c
@@ -42,6 +42,7 @@
 
 void *memset(void *, int, size_t);
 void *memcpy(void *, const void *, size_t);
+void *memmove(void *, const void *, size_t);
 
 #ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
 
@@ -81,6 +82,43 @@ static void *bump_alloc(size_t s) {
 static bool bump_allocated_instance = false;
 
 #endif
+
+static void *(*flanterm_alloc_ptr)(size_t) = NULL;
+static void (*flanterm_free_ptr)(void *) = NULL;
+
+static void *flanterm_alloc(size_t size)
+{
+    if (flanterm_alloc_ptr) {
+        return flanterm_alloc_ptr(size);
+    }
+#ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
+    return bump_alloc(size);
+#endif
+    return NULL;
+}
+
+static void flanterm_free(void *ptr)
+{
+    if (flanterm_free_ptr) {
+        flanterm_free_ptr(ptr);
+    }
+}
+
+void *sixel_malloc(size_t size) {
+    return flanterm_alloc(size);
+}
+
+void sixel_free(void *ptr) {
+    flanterm_free(ptr);
+}
+
+void *sixel_memset(void *dest, int ch, size_t count) {
+    return memset(dest, ch, count);
+}
+
+void *sixel_memcpy(void *dest, const void *src, size_t count) {
+    return memcpy(dest, src, count);
+}
 
 // Builtin font originally taken from:
 // https://github.com/viler-int10h/vga-text-mode-fonts/raw/master/FONTS/PC-OTHER/TOSH-SAT.F16
@@ -475,13 +513,17 @@ static void plot_char_scaled_canvas(struct flanterm_context *_ctx, struct flante
     for (size_t gy = 0; gy < ctx->glyph_height; gy++) {
         uint8_t fy = gy / ctx->font_scale_y;
         volatile uint32_t *fb_line = ctx->framebuffer + x + (y + gy) * (ctx->pitch / 4);
-        uint32_t *canvas_line = ctx->canvas + x + (y + gy) * ctx->width;
         bool *glyph_pointer = glyph + (fy * ctx->font_width);
         for (size_t fx = 0; fx < ctx->font_width; fx++) {
             for (size_t i = 0; i < ctx->font_scale_x; i++) {
                 size_t gx = ctx->font_scale_x * fx + i;
-                uint32_t bg = c->bg == 0xffffffff ? canvas_line[gx] : c->bg;
-                uint32_t fg = c->fg == 0xffffffff ? canvas_line[gx] : c->fg;
+                size_t idx = x + (y + gy) * ctx->width + gx;
+                uint32_t canvas_colour = ctx->canvas[idx];
+                if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                    canvas_colour = ctx->sixel_canvas[idx];
+                }
+                uint32_t bg = c->bg == 0xffffffff ? canvas_colour : c->bg;
+                uint32_t fg = c->fg == 0xffffffff ? canvas_colour : c->fg;
                 fb_line[gx] = *glyph_pointer ? fg : bg;
             }
             glyph_pointer++;
@@ -513,6 +555,11 @@ static void plot_char_scaled_uncanvas(struct flanterm_context *_ctx, struct flan
         for (size_t fx = 0; fx < ctx->font_width; fx++) {
             for (size_t i = 0; i < ctx->font_scale_x; i++) {
                 size_t gx = ctx->font_scale_x * fx + i;
+                if (ctx->sixel_canvas != NULL) {
+                    size_t idx = x + (y + gy) * ctx->width + gx;
+                    bg = c->bg == 0xffffffff ? ctx->sixel_canvas[idx] : c->bg;
+                    fg = c->fg == 0xffffffff ? ctx->sixel_canvas[idx] : c->fg;
+                }
                 fb_line[gx] = *glyph_pointer ? fg : bg;
             }
             glyph_pointer++;
@@ -534,11 +581,15 @@ static void plot_char_unscaled_canvas(struct flanterm_context *_ctx, struct flan
     // naming: fx,fy for font coordinates, gx,gy for glyph coordinates
     for (size_t gy = 0; gy < ctx->glyph_height; gy++) {
         volatile uint32_t *fb_line = ctx->framebuffer + x + (y + gy) * (ctx->pitch / 4);
-        uint32_t *canvas_line = ctx->canvas + x + (y + gy) * ctx->width;
         bool *glyph_pointer = glyph + (gy * ctx->font_width);
         for (size_t fx = 0; fx < ctx->font_width; fx++) {
-            uint32_t bg = c->bg == 0xffffffff ? canvas_line[fx] : c->bg;
-            uint32_t fg = c->fg == 0xffffffff ? canvas_line[fx] : c->fg;
+            size_t idx = x + (y + gy) * ctx->width + fx;
+            uint32_t canvas_colour = ctx->canvas[idx];
+            if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                canvas_colour = ctx->sixel_canvas[idx];
+            }
+            uint32_t bg = c->bg == 0xffffffff ? canvas_colour : c->bg;
+            uint32_t fg = c->fg == 0xffffffff ? canvas_colour : c->fg;
             fb_line[fx] = *(glyph_pointer++) ? fg : bg;
         }
     }
@@ -565,6 +616,11 @@ static void plot_char_unscaled_uncanvas(struct flanterm_context *_ctx, struct fl
         volatile uint32_t *fb_line = ctx->framebuffer + x + (y + gy) * (ctx->pitch / 4);
         bool *glyph_pointer = glyph + (gy * ctx->font_width);
         for (size_t fx = 0; fx < ctx->font_width; fx++) {
+            if (ctx->sixel_canvas != NULL) {
+                size_t idx = x + (y + gy) * ctx->width + fx;
+                bg = c->bg == 0xffffffff ? ctx->sixel_canvas[idx] : c->bg;
+                fg = c->fg == 0xffffffff ? ctx->sixel_canvas[idx] : c->fg;
+            }
             fb_line[fx] = *(glyph_pointer++) ? fg : bg;
         }
     }
@@ -649,6 +705,29 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
     for (size_t i = 0; i < _ctx->cols; i++) {
         push_to_queue(_ctx, &empty, i, _ctx->scroll_bottom_margin - 1);
     }
+
+    size_t sixel_src_y = ctx->sixel_start_y;
+    size_t sixel_dest_y = 0;
+    if (sixel_src_y) {
+        sixel_dest_y = --ctx->sixel_start_y;
+        if (sixel_dest_y == 0) {
+            ctx->sixel_start_y = 1;
+        }
+    }
+
+    size_t sixel_end_y = ctx->sixel_end_y ? ctx->sixel_end_y-- : 0;
+    if (!sixel_end_y || sixel_src_y >= sixel_end_y) {
+        return;
+    }
+
+    memmove(ctx->sixel_canvas + sixel_dest_y * ctx->glyph_height * ctx->width,
+            ctx->sixel_canvas + sixel_src_y * ctx->glyph_height * ctx->width,
+            (sixel_end_y - sixel_src_y) * ctx->glyph_height * ctx->width * sizeof(uint32_t));
+
+    memset(ctx->sixel_canvas + ((sixel_end_y - 1) * ctx->glyph_height * ctx->width), 0,
+           ctx->glyph_height * ctx->width * sizeof(uint32_t));
+
+    _ctx->should_flush = true;
 }
 
 static void flanterm_fb_clear(struct flanterm_context *_ctx, bool move) {
@@ -802,6 +881,71 @@ static void draw_cursor(struct flanterm_context *_ctx) {
         ctx->map[i] = NULL;
     }
 }
+#define DIV_ROUNDUP(VALUE, DIV) ({ \
+    __auto_type DIV_ROUNDUP_value = VALUE; \
+    __auto_type DIV_ROUNDUP_div = DIV; \
+    (DIV_ROUNDUP_value + (DIV_ROUNDUP_div - 1)) / DIV_ROUNDUP_div; \
+})
+
+#define MIN(A, B) ({ \
+    __auto_type MIN_a = A; \
+    __auto_type MIN_b = B; \
+    MIN_a < MIN_b ? MIN_a : MIN_b; \
+})
+
+#define MAX(A, B) ({ \
+    __auto_type MAX_a = A; \
+    __auto_type MAX_b = B; \
+    MAX_a > MAX_b ? MAX_a : MAX_b; \
+})
+
+static void flanterm_fb_draw_sixel(struct flanterm_context *_ctx, uint8_t *pixels, int width, int height, uint8_t *palette)
+{
+    struct flanterm_fb_context *ctx = (void *)_ctx;
+
+    size_t real_width = MIN((size_t)width, _ctx->cols * ctx->glyph_width - ctx->cursor_x * ctx->glyph_width);
+    size_t real_height = MIN((size_t)height, _ctx->rows * ctx->glyph_height - _ctx->scroll_top_margin * ctx->glyph_height);
+
+    int start_cur_x = ctx->cursor_x;
+    int start_cur_y = ctx->cursor_y;
+
+    ctx->cursor_x += DIV_ROUNDUP(real_width, ctx->glyph_width);
+    if (ctx->cursor_x >= _ctx->cols) {
+        ctx->cursor_x = 0;
+        ctx->cursor_y++;
+    }
+
+    ctx->cursor_y += DIV_ROUNDUP(real_height, ctx->glyph_height);
+    while (ctx->cursor_y >= _ctx->rows) {
+        ctx->cursor_y--;
+        start_cur_y--;
+        flanterm_fb_scroll(_ctx);
+    }
+
+    if (start_cur_y < 0) {
+        start_cur_y = 0;
+    }
+
+    size_t px = ctx->offset_x + start_cur_x * ctx->glyph_width;
+    size_t py = ctx->offset_y + start_cur_y * ctx->glyph_height;
+
+    for (size_t gy = 0; gy < real_height; gy++) {
+        for (size_t fx = 0; fx < real_width; fx++) {
+            size_t index = pixels[gy * width + fx];
+            size_t colour = (palette[index * 3] << 16) | (palette[index * 3 + 1] << 8) | palette[index * 3 + 2];
+            ctx->sixel_canvas[(py + gy) * ctx->width + px + fx] = convert_colour(_ctx, colour);
+        }
+    }
+
+    ctx->sixel_start_y = ctx->sixel_end_y ? MIN((size_t)start_cur_y, ctx->sixel_start_y) : start_cur_y;
+    ctx->sixel_end_y = MIN(MAX(start_cur_y + DIV_ROUNDUP(real_height, ctx->glyph_height), ctx->sixel_end_y), _ctx->rows);
+
+    _ctx->should_flush = true;
+}
+
+#undef DIV_ROUNDUP
+#undef MAX
+#undef MIN
 
 static void flanterm_fb_double_buffer_flush(struct flanterm_context *_ctx) {
     struct flanterm_fb_context *ctx = (void *)_ctx;
@@ -862,10 +1006,20 @@ static void flanterm_fb_full_refresh(struct flanterm_context *_ctx) {
 
     for (size_t y = 0; y < ctx->height; y++) {
         for (size_t x = 0; x < ctx->width; x++) {
+            volatile uint32_t *fb_line = ctx->framebuffer + y * (ctx->pitch / 4) + x;
+            size_t idx = y * ctx->width + x;
             if (ctx->canvas != NULL) {
-                ctx->framebuffer[y * (ctx->pitch / sizeof(uint32_t)) + x] = ctx->canvas[y * ctx->width + x];
+                uint32_t colour = ctx->canvas[idx];
+                if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                    colour = ctx->sixel_canvas[idx];
+                }
+                *fb_line = colour;
             } else {
-                ctx->framebuffer[y * (ctx->pitch / sizeof(uint32_t)) + x] = default_bg;
+                uint32_t colour = default_bg;
+                if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                    colour = ctx->sixel_canvas[idx];
+                }
+                *fb_line = colour;
             }
         }
     }
@@ -882,35 +1036,25 @@ static void flanterm_fb_full_refresh(struct flanterm_context *_ctx) {
     }
 }
 
-static void flanterm_fb_deinit(struct flanterm_context *_ctx, void (*_free)(void *, size_t)) {
+static void flanterm_fb_deinit(struct flanterm_context *_ctx) {
     struct flanterm_fb_context *ctx = (void *)_ctx;
 
-    if (_free == NULL) {
-#ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
-        if (bump_allocated_instance == true) {
-            bump_alloc_ptr = 0;
-            bump_allocated_instance = false;
-        }
-#endif
-        return;
-    }
-
-    _free(ctx->font_bits, ctx->font_bits_size);
-    _free(ctx->font_bool, ctx->font_bool_size);
-    _free(ctx->grid, ctx->grid_size);
-    _free(ctx->queue, ctx->queue_size);
-    _free(ctx->map, ctx->map_size);
+    flanterm_free(ctx->font_bits);
+    flanterm_free(ctx->font_bool);
+    flanterm_free(ctx->grid);
+    flanterm_free(ctx->queue);
+    flanterm_free(ctx->map);
 
     if (ctx->canvas != NULL) {
-        _free(ctx->canvas, ctx->canvas_size);
+        flanterm_free(ctx->canvas);
     }
 
-    _free(ctx, sizeof(struct flanterm_fb_context));
+    flanterm_free(ctx);
 }
 
 struct flanterm_context *flanterm_fb_init(
     void *(*_malloc)(size_t),
-    void (*_free)(void *, size_t),
+    void (*_free)(void *),
     uint32_t *framebuffer, size_t width, size_t height, size_t pitch,
     uint8_t red_mask_size, uint8_t red_mask_shift,
     uint8_t green_mask_size, uint8_t green_mask_shift,
@@ -940,12 +1084,21 @@ struct flanterm_context *flanterm_fb_init(
         return NULL;
     }
 
+    bool sixel_supported = true;
+#ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
+    bool using_bump = false;
+#endif
+
+    flanterm_alloc_ptr = _malloc;
+    flanterm_free_ptr = _free;
+
     if (_malloc == NULL) {
 #ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
         if (bump_allocated_instance == true) {
             return NULL;
         }
-        _malloc = bump_alloc;
+        using_bump = true;
+
         // Limit terminal size if needed
         if (width > FLANTERM_FB_WIDTH_LIMIT || height > FLANTERM_FB_HEIGHT_LIMIT) {
             size_t width_limit = width > FLANTERM_FB_WIDTH_LIMIT ? FLANTERM_FB_WIDTH_LIMIT : width;
@@ -957,15 +1110,16 @@ struct flanterm_context *flanterm_fb_init(
             height = height_limit;
         }
 
-        // Force disable canvas
+        // Force disable canvas and sixel support
         canvas = NULL;
+        sixel_supported = false;
 #else
         return NULL;
 #endif
     }
 
     struct flanterm_fb_context *ctx = NULL;
-    ctx = _malloc(sizeof(struct flanterm_fb_context));
+    ctx = flanterm_alloc(sizeof(struct flanterm_fb_context));
     if (ctx == NULL) {
         goto fail;
     }
@@ -1048,7 +1202,7 @@ struct flanterm_context *flanterm_fb_init(
         ctx->font_width = font_width;
         ctx->font_height = font_height;
         ctx->font_bits_size = FONT_BYTES;
-        ctx->font_bits = _malloc(ctx->font_bits_size);
+        ctx->font_bits = flanterm_alloc(ctx->font_bits_size);
         if (ctx->font_bits == NULL) {
             goto fail;
         }
@@ -1058,7 +1212,7 @@ struct flanterm_context *flanterm_fb_init(
         ctx->font_height = font_height = 16;
         ctx->font_bits_size = FONT_BYTES;
         font_spacing = 1;
-        ctx->font_bits = _malloc(ctx->font_bits_size);
+        ctx->font_bits = flanterm_alloc(ctx->font_bits_size);
         if (ctx->font_bits == NULL) {
             goto fail;
         }
@@ -1070,7 +1224,7 @@ struct flanterm_context *flanterm_fb_init(
     ctx->font_width += font_spacing;
 
     ctx->font_bool_size = FLANTERM_FB_FONT_GLYPHS * font_height * ctx->font_width * sizeof(bool);
-    ctx->font_bool = _malloc(ctx->font_bool_size);
+    ctx->font_bool = flanterm_alloc(ctx->font_bool_size);
     if (ctx->font_bool == NULL) {
         goto fail;
     }
@@ -1117,7 +1271,7 @@ struct flanterm_context *flanterm_fb_init(
     ctx->offset_y = margin + ((ctx->height - margin * 2) % ctx->glyph_height) / 2;
 
     ctx->grid_size = _ctx->rows * _ctx->cols * sizeof(struct flanterm_fb_char);
-    ctx->grid = _malloc(ctx->grid_size);
+    ctx->grid = flanterm_alloc(ctx->grid_size);
     if (ctx->grid == NULL) {
         goto fail;
     }
@@ -1128,7 +1282,7 @@ struct flanterm_context *flanterm_fb_init(
     }
 
     ctx->queue_size = _ctx->rows * _ctx->cols * sizeof(struct flanterm_fb_queue_item);
-    ctx->queue = _malloc(ctx->queue_size);
+    ctx->queue = flanterm_alloc(ctx->queue_size);
     if (ctx->queue == NULL) {
         goto fail;
     }
@@ -1136,15 +1290,15 @@ struct flanterm_context *flanterm_fb_init(
     memset(ctx->queue, 0, ctx->queue_size);
 
     ctx->map_size = _ctx->rows * _ctx->cols * sizeof(struct flanterm_fb_queue_item *);
-    ctx->map = _malloc(ctx->map_size);
+    ctx->map = flanterm_alloc(ctx->map_size);
     if (ctx->map == NULL) {
         goto fail;
     }
     memset(ctx->map, 0, ctx->map_size);
 
+    ctx->canvas_size = ctx->width * ctx->height * sizeof(uint32_t);
     if (canvas != NULL) {
-        ctx->canvas_size = ctx->width * ctx->height * sizeof(uint32_t);
-        ctx->canvas = _malloc(ctx->canvas_size);
+        ctx->canvas = flanterm_alloc(ctx->canvas_size);
         if (ctx->canvas == NULL) {
             goto fail;
         }
@@ -1152,6 +1306,21 @@ struct flanterm_context *flanterm_fb_init(
             ctx->canvas[i] = convert_colour(_ctx, canvas[i]);
         }
     }
+
+    _ctx->sixel_supported = sixel_supported;
+    if (sixel_supported) {
+        ctx->sixel_canvas = flanterm_alloc(ctx->canvas_size);
+        if (ctx->sixel_canvas == NULL) {
+            goto fail;
+        }
+        memset(ctx->sixel_canvas, 0, ctx->canvas_size);
+    }
+    else {
+        ctx->sixel_canvas = NULL;
+    }
+
+    ctx->sixel_start_y = 0;
+    ctx->sixel_end_y = 0;
 
     if (font_scale_x == 1 && font_scale_y == 1) {
         if (canvas == NULL) {
@@ -1168,6 +1337,7 @@ struct flanterm_context *flanterm_fb_init(
     }
 
     _ctx->raw_putchar = flanterm_fb_raw_putchar;
+    _ctx->draw_sixel = flanterm_fb_draw_sixel;
     _ctx->clear = flanterm_fb_clear;
     _ctx->set_cursor_pos = flanterm_fb_set_cursor_pos;
     _ctx->get_cursor_pos = flanterm_fb_get_cursor_pos;
@@ -1195,7 +1365,7 @@ struct flanterm_context *flanterm_fb_init(
     flanterm_fb_full_refresh(_ctx);
 
 #ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
-    if (_malloc == bump_alloc) {
+    if (using_bump) {
         bump_allocated_instance = true;
     }
 #endif
@@ -1208,7 +1378,7 @@ fail:
     }
 
 #ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
-    if (_malloc == bump_alloc) {
+    if (using_bump) {
         bump_alloc_ptr = 0;
         return NULL;
     }
@@ -1219,25 +1389,28 @@ fail:
     }
 
     if (ctx->canvas != NULL) {
-        _free(ctx->canvas, ctx->canvas_size);
+        _free(ctx->canvas);
+    }
+    if (ctx->sixel_canvas != NULL) {
+        _free(ctx->sixel_canvas);
     }
     if (ctx->map != NULL) {
-        _free(ctx->map, ctx->map_size);
+        _free(ctx->map);
     }
     if (ctx->queue != NULL) {
-        _free(ctx->queue, ctx->queue_size);
+        _free(ctx->queue);
     }
     if (ctx->grid != NULL) {
-        _free(ctx->grid, ctx->grid_size);
+        _free(ctx->grid);
     }
     if (ctx->font_bool != NULL) {
-        _free(ctx->font_bool, ctx->font_bool_size);
+        _free(ctx->font_bool);
     }
     if (ctx->font_bits != NULL) {
-        _free(ctx->font_bits, ctx->font_bits_size);
+        _free(ctx->font_bits);
     }
     if (ctx != NULL) {
-        _free(ctx, sizeof(struct flanterm_fb_context));
+        _free(ctx);
     }
 
     return NULL;

--- a/backends/fb.c
+++ b/backends/fb.c
@@ -682,6 +682,7 @@ static void flanterm_fb_revscroll(struct flanterm_context *_ctx) {
     }
 }
 
+static void flanterm_fb_sixel_refresh(struct flanterm_context *_ctx, size_t start_y, size_t height);
 static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
     struct flanterm_fb_context *ctx = (void *)_ctx;
 
@@ -706,13 +707,25 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
         push_to_queue(_ctx, &empty, i, _ctx->scroll_bottom_margin - 1);
     }
 
+    if (!_ctx->sixel_supported) {
+        return;
+    }
+
     size_t sixel_src_y = ctx->sixel_start_y;
     size_t sixel_dest_y = 0;
-    if (sixel_src_y) {
-        sixel_dest_y = --ctx->sixel_start_y;
-        if (sixel_dest_y == 0) {
-            ctx->sixel_start_y = 1;
-        }
+
+    switch (sixel_src_y) {
+        case 0:
+            sixel_src_y = 1;
+            sixel_dest_y = 0;
+            break;
+        case 1:
+            ctx->sixel_start_y = 0;
+            sixel_dest_y = 0;
+            break;
+        default:
+            sixel_dest_y = --ctx->sixel_start_y;
+            break;
     }
 
     size_t sixel_end_y = ctx->sixel_end_y ? ctx->sixel_end_y-- : 0;
@@ -720,14 +733,22 @@ static void flanterm_fb_scroll(struct flanterm_context *_ctx) {
         return;
     }
 
-    memmove(ctx->sixel_canvas + sixel_dest_y * ctx->glyph_height * ctx->width,
-            ctx->sixel_canvas + sixel_src_y * ctx->glyph_height * ctx->width,
-            (sixel_end_y - sixel_src_y) * ctx->glyph_height * ctx->width * sizeof(uint32_t));
+    for (size_t cy = 0; cy < (sixel_end_y - sixel_src_y); cy++) {
+        for (size_t line = 0; line < ctx->glyph_height; line++) {
+            size_t offset = line * ctx->width;
+            memcpy(ctx->sixel_canvas + (cy + sixel_dest_y) * ctx->glyph_height * ctx->width + offset + ctx->sixel_start_x * ctx->glyph_width,
+                   ctx->sixel_canvas + (cy + sixel_src_y) * ctx->glyph_height * ctx->width + offset + ctx->sixel_start_x * ctx->glyph_width,
+                   (ctx->sixel_end_x - ctx->sixel_start_x) * ctx->glyph_width * sizeof(uint32_t));
+        }
+    }
 
-    memset(ctx->sixel_canvas + ((sixel_end_y - 1) * ctx->glyph_height * ctx->width), 0,
-           ctx->glyph_height * ctx->width * sizeof(uint32_t));
+    for (size_t cy = 0; cy < ctx->glyph_height; cy++) {
+        size_t offset = cy * ctx->width;
+        memset(ctx->sixel_canvas + (sixel_end_y - 1) * ctx->glyph_height * ctx->width + offset + ctx->sixel_start_x * ctx->glyph_width, 0,
+               (ctx->sixel_end_x - ctx->sixel_start_x) * ctx->glyph_width * sizeof(uint32_t));
+    }
 
-    _ctx->should_flush = true;
+    flanterm_fb_sixel_refresh(_ctx, sixel_end_y - 1, 1);
 }
 
 static void flanterm_fb_clear(struct flanterm_context *_ctx, bool move) {
@@ -917,9 +938,12 @@ static void flanterm_fb_draw_sixel(struct flanterm_context *_ctx, uint8_t *pixel
 
     ctx->cursor_y += DIV_ROUNDUP(real_height, ctx->glyph_height);
     while (ctx->cursor_y >= _ctx->rows) {
-        ctx->cursor_y--;
         start_cur_y--;
+        ctx->cursor_y--;
         flanterm_fb_scroll(_ctx);
+        if (ctx->cursor_y == _ctx->rows) {
+            ctx->cursor_y--;
+        }
     }
 
     if (start_cur_y < 0) {
@@ -937,10 +961,16 @@ static void flanterm_fb_draw_sixel(struct flanterm_context *_ctx, uint8_t *pixel
         }
     }
 
+    flanterm_free(pixels);
+    flanterm_free(palette);
+
     ctx->sixel_start_y = ctx->sixel_end_y ? MIN((size_t)start_cur_y, ctx->sixel_start_y) : start_cur_y;
     ctx->sixel_end_y = MIN(MAX(start_cur_y + DIV_ROUNDUP(real_height, ctx->glyph_height), ctx->sixel_end_y), _ctx->rows);
 
-    _ctx->should_flush = true;
+    ctx->sixel_start_x = ctx->sixel_end_x ? MIN((size_t)start_cur_x, ctx->sixel_start_x) : start_cur_x;
+    ctx->sixel_end_x = MIN(MAX(start_cur_x + DIV_ROUNDUP(real_width, ctx->glyph_width), ctx->sixel_end_x), _ctx->cols);
+
+    flanterm_fb_sixel_refresh(_ctx,ctx->sixel_start_y, ctx->sixel_end_y - ctx->sixel_start_y);
 }
 
 #undef DIV_ROUNDUP
@@ -1033,6 +1063,42 @@ static void flanterm_fb_full_refresh(struct flanterm_context *_ctx) {
 
     if (_ctx->cursor_enabled) {
         draw_cursor(_ctx);
+    }
+}
+
+static void flanterm_fb_sixel_refresh(struct flanterm_context *_ctx, size_t start_y, size_t height) {
+    struct flanterm_fb_context *ctx = (void *)_ctx;
+
+    uint32_t default_bg = ctx->default_bg;
+
+    for (size_t y = (start_y * ctx->glyph_height); y < ((start_y + height) * ctx->glyph_height); y++) {
+        size_t end = ((ctx->sixel_start_x + (ctx->sixel_end_x - ctx->sixel_start_x)) * ctx->glyph_width);
+        for (size_t x = (ctx->sixel_start_x * ctx->glyph_width); x < end; x++) {
+            volatile uint32_t *fb_line = ctx->framebuffer + y * (ctx->pitch / 4) + x;
+            size_t idx = y * ctx->width + x;
+            if (ctx->canvas != NULL) {
+                uint32_t colour = ctx->canvas[idx];
+                if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                    colour = ctx->sixel_canvas[idx];
+                }
+                *fb_line = colour;
+            } else {
+                uint32_t colour = default_bg;
+                if (ctx->sixel_canvas != NULL && ctx->sixel_canvas[idx]) {
+                    colour = ctx->sixel_canvas[idx];
+                }
+                *fb_line = colour;
+            }
+        }
+    }
+
+    for (size_t cy = ctx->sixel_start_y; cy < ctx->sixel_end_y; cy++) {
+        for (size_t i = cy * _ctx->cols + ctx->sixel_start_x; i < (cy * _ctx->cols + ctx->sixel_end_x); i++) {
+            size_t x = i % _ctx->cols;
+            size_t y = i / _ctx->cols;
+
+            ctx->plot_char(_ctx, &ctx->grid[i], x, y);
+        }
     }
 }
 

--- a/backends/fb.c
+++ b/backends/fb.c
@@ -42,7 +42,6 @@
 
 void *memset(void *, int, size_t);
 void *memcpy(void *, const void *, size_t);
-void *memmove(void *, const void *, size_t);
 
 #ifndef FLANTERM_FB_DISABLE_BUMP_ALLOC
 

--- a/backends/fb.h
+++ b/backends/fb.h
@@ -43,9 +43,9 @@ extern "C" {
 #endif
 
 struct flanterm_context *flanterm_fb_init(
-    /* If _malloc and _free are nulled, use the bump allocated instance (1 use only). */
+    /* If _malloc and _free are NULL, sixel support is disabled */
     void *(*_malloc)(size_t),
-    void (*_free)(void *, size_t),
+    void (*_free)(void *),
     uint32_t *framebuffer, size_t width, size_t height, size_t pitch,
     uint8_t red_mask_size, uint8_t red_mask_shift,
     uint8_t green_mask_size, uint8_t green_mask_shift,

--- a/backends/fb_private.h
+++ b/backends/fb_private.h
@@ -91,7 +91,9 @@ struct flanterm_fb_context {
     uint32_t *sixel_canvas;
 
     size_t sixel_start_y;
+    size_t sixel_start_x;
     size_t sixel_end_y;
+    size_t sixel_end_x;
 
     size_t grid_size;
     size_t queue_size;

--- a/backends/fb_private.h
+++ b/backends/fb_private.h
@@ -88,6 +88,10 @@ struct flanterm_fb_context {
 
     size_t canvas_size;
     uint32_t *canvas;
+    uint32_t *sixel_canvas;
+
+    size_t sixel_start_y;
+    size_t sixel_end_y;
 
     size_t grid_size;
     size_t queue_size;

--- a/flanterm.c
+++ b/flanterm.c
@@ -82,7 +82,6 @@ static const uint32_t col256[] = {
 void flanterm_context_reinit(struct flanterm_context *ctx) {
     ctx->tab_size = 8;
     ctx->autoflush = true;
-    ctx->should_flush = false;
     ctx->cursor_enabled = true;
     ctx->scroll_enabled = true;
     ctx->control_sequence = false;
@@ -170,11 +169,6 @@ void flanterm_write(struct flanterm_context *ctx, const char *buf, size_t count)
 
     if (ctx->autoflush) {
         ctx->double_buffer_flush(ctx);
-    }
-
-    if (ctx->should_flush) {
-        ctx->full_refresh(ctx);
-        ctx->should_flush = false;
     }
 }
 

--- a/flanterm.c
+++ b/flanterm.c
@@ -38,6 +38,7 @@
 #define FLANTERM_IN_FLANTERM
 
 #include "flanterm.h"
+#include "sixel/sixel.h"
 
 // Tries to implement this standard for terminfo
 // https://man7.org/linux/man-pages/man4/console_codes.4.html
@@ -81,6 +82,7 @@ static const uint32_t col256[] = {
 void flanterm_context_reinit(struct flanterm_context *ctx) {
     ctx->tab_size = 8;
     ctx->autoflush = true;
+    ctx->should_flush = false;
     ctx->cursor_enabled = true;
     ctx->scroll_enabled = true;
     ctx->control_sequence = false;
@@ -110,15 +112,69 @@ void flanterm_context_reinit(struct flanterm_context *ctx) {
     ctx->oob_output = FLANTERM_OOB_OUTPUT_ONLCR;
 }
 
+static bool is_sixel(const char *buf, size_t count, size_t *end) {
+    if (count < 3 || buf[0] != 0x1b || buf[1] != 'P') {
+        return false;
+    }
+
+    size_t i = 0;
+    char *cur = (char *)buf + 2;
+    while (cur < (buf + count) && i <= 30) {
+        if ((*cur < '0' || *cur > '9') && *cur != ';' && *cur != 'q') {
+            return false;
+        }
+        if (*cur == 'q') {
+            goto found;
+        }
+        if (*cur == ';') {
+            i++;
+        }
+        cur++;
+    }
+    return false;
+
+found:
+    while (cur < (buf + count - 1)) {
+        if (*cur == 0x1b && *(cur + 1) == '\\') {
+            *end = cur - buf;
+            return true;
+        }
+        cur++;
+    }
+    *end = 0;
+    return false;
+}
+
 static void flanterm_putchar(struct flanterm_context *ctx, uint8_t c);
 
 void flanterm_write(struct flanterm_context *ctx, const char *buf, size_t count) {
+    size_t sixel_end = 0;
+    if (ctx->sixel_supported && is_sixel(buf, count, &sixel_end)) {
+        unsigned char *pixels, *palette;
+        int width, height, ncolors;
+
+        sixel_decode_raw((unsigned char *)buf, count, &pixels, &width, &height, &palette, &ncolors);
+        ctx->draw_sixel(ctx, pixels, width, height, palette);
+
+        if (!sixel_end) {
+            return;
+        }
+
+        buf += sixel_end;
+        count -= sixel_end;
+    }
+
     for (size_t i = 0; i < count; i++) {
         flanterm_putchar(ctx, buf[i]);
     }
 
     if (ctx->autoflush) {
         ctx->double_buffer_flush(ctx);
+    }
+
+    if (ctx->should_flush) {
+        ctx->full_refresh(ctx);
+        ctx->should_flush = false;
     }
 }
 
@@ -1362,8 +1418,8 @@ void flanterm_full_refresh(struct flanterm_context *ctx) {
     ctx->full_refresh(ctx);
 }
 
-void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, size_t)) {
-    ctx->deinit(ctx, _free);
+void flanterm_deinit(struct flanterm_context *ctx) {
+    ctx->deinit(ctx);
 }
 
 void flanterm_get_dimensions(struct flanterm_context *ctx, size_t *cols, size_t *rows) {

--- a/flanterm.h
+++ b/flanterm.h
@@ -65,7 +65,7 @@ struct flanterm_context;
 void flanterm_write(struct flanterm_context *ctx, const char *buf, size_t count);
 void flanterm_flush(struct flanterm_context *ctx);
 void flanterm_full_refresh(struct flanterm_context *ctx);
-void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, size_t));
+void flanterm_deinit(struct flanterm_context *ctx);
 
 void flanterm_get_dimensions(struct flanterm_context *ctx, size_t *rows, size_t *cols);
 void flanterm_set_autoflush(struct flanterm_context *ctx, bool state);

--- a/flanterm_private.h
+++ b/flanterm_private.h
@@ -46,7 +46,6 @@ struct flanterm_context {
     size_t tab_size;
     bool autoflush;
     bool sixel_supported;
-    bool should_flush;
     bool cursor_enabled;
     bool scroll_enabled;
     bool control_sequence;

--- a/flanterm_private.h
+++ b/flanterm_private.h
@@ -45,6 +45,8 @@ struct flanterm_context {
 
     size_t tab_size;
     bool autoflush;
+    bool sixel_supported;
+    bool should_flush;
     bool cursor_enabled;
     bool scroll_enabled;
     bool control_sequence;
@@ -85,6 +87,7 @@ struct flanterm_context {
     size_t rows, cols;
 
     void (*raw_putchar)(struct flanterm_context *, uint8_t c);
+    void (*draw_sixel)(struct flanterm_context *, uint8_t *pixels, int width, int height, uint8_t *palette);
     void (*clear)(struct flanterm_context *, bool move);
     void (*set_cursor_pos)(struct flanterm_context *, size_t x, size_t y);
     void (*get_cursor_pos)(struct flanterm_context *, size_t *x, size_t *y);
@@ -106,7 +109,7 @@ struct flanterm_context {
     void (*restore_state)(struct flanterm_context *);
     void (*double_buffer_flush)(struct flanterm_context *);
     void (*full_refresh)(struct flanterm_context *);
-    void (*deinit)(struct flanterm_context *, void (*)(void *, size_t));
+    void (*deinit)(struct flanterm_context *);
 
     /* to be set by client */
 

--- a/sixel/sixel.c
+++ b/sixel/sixel.c
@@ -1,0 +1,877 @@
+/*
+ * This file is derived from "sixel" original version (2014-3-2)
+ * http://nanno.dip.jp/softlib/man/rlogin/sixel.tar.gz
+ *
+ * Initial developer of this file is kmiya@culti.
+ *
+ * He distributes it under very permissive license which permits
+ * useing, copying, modification, redistribution, and all other
+ * public activities without any restrictions.
+ *
+ * He declares this is compatible with MIT/BSD/GPL.
+ *
+ * Hayaki Saito <saitoha@me.com> modified this and re-licensed
+ * it to the MIT license.
+ */
+
+#include "sixel.h"
+#include "sixel_api.h"
+
+#if __has_include(<limits.h>)
+#  include <limits.h>
+#else
+#  define INT_MAX __INT_MAX__
+#endif
+
+#define SIXEL_RGB(r, g, b) (((r) << 16) + ((g) << 8) +  (b))
+#define PALVAL(n,a,m) (((n) * (a) + ((m) / 2)) / (m))
+#define SIXEL_XRGB(r,g,b) SIXEL_RGB(PALVAL(r, 255, 100), PALVAL(g, 255, 100), PALVAL(b, 255, 100))
+
+#define DECSIXEL_PARAMS_MAX 16
+
+static int const sixel_default_color_table[] = {
+    SIXEL_XRGB(0,  0,  0),   /*  0 Black    */
+    SIXEL_XRGB(20, 20, 80),  /*  1 Blue     */
+    SIXEL_XRGB(80, 13, 13),  /*  2 Red      */
+    SIXEL_XRGB(20, 80, 20),  /*  3 Green    */
+    SIXEL_XRGB(80, 20, 80),  /*  4 Magenta  */
+    SIXEL_XRGB(20, 80, 80),  /*  5 Cyan     */
+    SIXEL_XRGB(80, 80, 20),  /*  6 Yellow   */
+    SIXEL_XRGB(53, 53, 53),  /*  7 Gray 50% */
+    SIXEL_XRGB(26, 26, 26),  /*  8 Gray 25% */
+    SIXEL_XRGB(33, 33, 60),  /*  9 Blue*    */
+    SIXEL_XRGB(60, 26, 26),  /* 10 Red*     */
+    SIXEL_XRGB(33, 60, 33),  /* 11 Green*   */
+    SIXEL_XRGB(60, 33, 60),  /* 12 Magenta* */
+    SIXEL_XRGB(33, 60, 60),  /* 13 Cyan*    */
+    SIXEL_XRGB(60, 60, 33),  /* 14 Yellow*  */
+    SIXEL_XRGB(80, 80, 80),  /* 15 Gray 75% */
+};
+
+typedef struct image_buffer {
+    unsigned char *data;
+    int width;
+    int height;
+    int palette[SIXEL_PALETTE_MAX];
+    int ncolors;
+} image_buffer_t;
+
+typedef enum parse_state {
+    PS_GROUND     = 0,
+    PS_ESC        = 1,  /* ESC */
+    PS_DCS        = 2,  /* DCS Device Control String Introducer \033P P...P I...I F */
+    PS_DECSIXEL   = 3,  /* DECSIXEL body part ", $, -, ? ... ~ */
+    PS_DECGRA     = 4,  /* DECGRA Set Raster Attributes " Pan; Pad; Ph; Pv */
+    PS_DECGRI     = 5,  /* DECGRI Graphics Repeat Introducer ! Pn Ch */
+    PS_DECGCI     = 6   /* DECGCI Graphics Color Introducer # Pc; Pu; Px; Py; Pz */
+} parse_state_t;
+
+typedef struct parser_context {
+    parse_state_t state;
+    int pos_x;
+    int pos_y;
+    int max_x;
+    int max_y;
+    int attributed_pan;
+    int attributed_pad;
+    int attributed_ph;
+    int attributed_pv;
+    int repeat_count;
+    int color_index;
+    int bgindex;
+    int param;
+    int nparams;
+    int params[DECSIXEL_PARAMS_MAX];
+} parser_context_t;
+
+#define INT_CLAMP(val, min_val, max_val) \
+    ((val) < (min_val) ? (min_val) : ((val) > (max_val) ? (max_val) : (val)))
+
+// TODO: might result in a bit incorrect r value
+static int hls_to_rgb(int h, int l, int s) {
+    if (s == 0) {
+        return SIXEL_XRGB(l, l, l);
+    }
+
+    h = h % 360;
+    if (h < 0) {
+        h += 360;
+    }
+    h = (h * 255) / 360;
+    l = INT_CLAMP(l, 0, 100) * 255 / 100;
+    s = INT_CLAMP(s, 0, 100) * 255 / 100;
+
+    int temp2 = (l <= 127) ? (l * (255 + s)) / 255 : l + s - (l * s) / 255;
+    int temp1 = 2 * l - temp2;
+
+    int r = 0, g = 0, b = 0;
+
+    for (int i = 0; i < 3; ++i) {
+        int tempH = h + (i * 85);
+        tempH = tempH % 256;
+        if (tempH < 0) {
+            tempH += 256;
+        }
+
+        int color;
+        if (tempH < 43) {
+            color = temp1 + ((temp2 - temp1) * tempH) / 43;
+        } else if (tempH < 128) {
+            color = temp2;
+        } else if (tempH < 170) {
+            color = temp1 + ((temp2 - temp1) * (170 - tempH)) / 43;
+        } else {
+            color = temp1;
+        }
+
+        if (i == 0) {
+            r = color;
+        } else if (i == 1) {
+            g = color;
+        } else {
+            b = color;
+        }
+    }
+
+    return SIXEL_XRGB(r, g, b);
+}
+#undef INT_CLAMP
+
+static SIXELSTATUS image_buffer_init(image_buffer_t *image, int width, int height, int bgindex)
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+    size_t size;
+    int i;
+    int n;
+    int r;
+    int g;
+    int b;
+
+    /* check parameters */
+    if (width <= 0) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (height <= 0) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (width > SIXEL_WIDTH_LIMIT) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (height > SIXEL_HEIGHT_LIMIT) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+
+    size = (size_t)(width) * (size_t)height * sizeof(unsigned char);
+    image->width = width;
+    image->height = height;
+    image->data = (unsigned char *)sixel_malloc(size);
+    image->ncolors = 2;
+
+    if (image->data == NULL) {
+        status = SIXEL_BAD_ALLOCATION;
+        goto end;
+    }
+    sixel_memset(image->data, bgindex, size);
+
+    /* palette initialization */
+    for (n = 0; n < 16; n++) {
+        image->palette[n] = sixel_default_color_table[n];
+    }
+
+    /* colors 16-231 are a 6x6x6 color cube */
+    for (r = 0; r < 6; r++) {
+        for (g = 0; g < 6; g++) {
+            for (b = 0; b < 6; b++) {
+                image->palette[n++] = SIXEL_RGB(r * 51, g * 51, b * 51);
+            }
+        }
+    }
+
+    /* colors 232-255 are a grayscale ramp, intentionally leaving out */
+    for (i = 0; i < 24; i++) {
+        image->palette[n++] = SIXEL_RGB(i * 11, i * 11, i * 11);
+    }
+
+    for (; n < SIXEL_PALETTE_MAX; n++) {
+        image->palette[n] = SIXEL_RGB(255, 255, 255);
+    }
+
+    status = SIXEL_OK;
+
+end:
+    return status;
+}
+
+static SIXELSTATUS image_buffer_resize(image_buffer_t *image, int width, int height, int bgindex)
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+    size_t size;
+    unsigned char *alt_buffer;
+    int n;
+    int min_height;
+
+    /* check parameters */
+    if (width <= 0) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (height <= 0) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (height > SIXEL_HEIGHT_LIMIT) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (width > SIXEL_WIDTH_LIMIT) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+    if (height > SIXEL_HEIGHT_LIMIT) {
+        status = SIXEL_BAD_INPUT;
+        goto end;
+    }
+
+    size = (size_t)width * (size_t)height;
+    alt_buffer = (unsigned char *)sixel_malloc(size);
+    if (alt_buffer == NULL || size == 0) {
+        /* free source image */
+        sixel_free(image->data);
+        image->data = NULL;
+        status = SIXEL_BAD_ALLOCATION;
+        goto end;
+    }
+
+    min_height = height > image->height ? image->height: height;
+    if (width > image->width) {  /* if width is extended */
+        for (n = 0; n < min_height; ++n) {
+            /* copy from source image */
+            sixel_memcpy(alt_buffer + (size_t)width * (size_t)n,
+                   image->data + (size_t)image->width * (size_t)n,
+                   (size_t)image->width);
+            /* fill extended area with background color */
+            sixel_memset(alt_buffer + (size_t)width * (size_t)n + (size_t)image->width,
+                   bgindex,
+                   (size_t)(width - image->width));
+        }
+    } else {
+        for (n = 0; n < min_height; ++n) {
+            /* copy from source image */
+            sixel_memcpy(alt_buffer + (size_t)width * (size_t)n,
+                   image->data + (size_t)image->width * (size_t)n,
+                   (size_t)width);
+        }
+    }
+
+    if (height > image->height) {  /* if height is extended */
+        /* fill extended area with background color */
+        sixel_memset(alt_buffer + (size_t)width * (size_t)image->height,
+               bgindex,
+               (size_t)width * (size_t)(height - image->height));
+    }
+
+    /* free source image */
+    sixel_free(image->data);
+
+    image->data = alt_buffer;
+    image->width = width;
+    image->height = height;
+
+    status = SIXEL_OK;
+
+end:
+    return status;
+}
+
+static SIXELSTATUS parser_context_init(parser_context_t *context)
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+
+    context->state = PS_GROUND;
+    context->pos_x = 0;
+    context->pos_y = 0;
+    context->max_x = 0;
+    context->max_y = 0;
+    context->attributed_pan = 2;
+    context->attributed_pad = 1;
+    context->attributed_ph = 0;
+    context->attributed_pv = 0;
+    context->repeat_count = 1;
+    context->color_index = 15;
+    context->bgindex = (-1);
+    context->nparams = 0;
+    context->param = 0;
+
+    status = SIXEL_OK;
+
+    return status;
+}
+
+static SIXELSTATUS safe_addition_for_params(parser_context_t *context, unsigned char *p)
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+    int x;
+
+    x = *p - '0'; /* 0 <= x <= 9 */
+    if ((context->param > INT_MAX / 10) || (x > INT_MAX - context->param * 10)) {
+        status = SIXEL_BAD_INTEGER_OVERFLOW;
+        goto end;
+    }
+    context->param = context->param * 10 + x;
+    status = SIXEL_OK;
+
+end:
+    return status;
+}
+
+/* convert sixel data into indexed pixel bytes and palette data */
+static SIXELSTATUS sixel_decode_raw_impl(unsigned char *p, int len, image_buffer_t *image, parser_context_t *context)
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+    int n, i, y, bits;
+    int sixel_vertical_mask;
+    int sx, sy, c;
+    size_t pos;
+    unsigned char *p0 = p;
+
+    while (p < p0 + len) {
+        switch (context->state) {
+        case PS_GROUND:
+            switch (*p) {
+            case 0x1b:
+                context->state = PS_ESC;
+                p++;
+                break;
+            case 0x90:
+                context->state = PS_DCS;
+                p++;
+                break;
+            case 0x9c:
+                p++;
+                goto finalize;
+            default:
+                p++;
+                break;
+            }
+            break;
+
+        case PS_ESC:
+            switch (*p) {
+            case '\\':
+            case 0x9c:
+                p++;
+                goto finalize;
+            case 'P':
+                context->param = -1;
+                context->state = PS_DCS;
+                p++;
+                break;
+            default:
+                p++;
+                break;
+            }
+            break;
+
+        case PS_DCS:
+            switch (*p) {
+            case 0x1b:
+                context->state = PS_ESC;
+                p++;
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                if (context->param < 0) {
+                    context->param = 0;
+                }
+                status = safe_addition_for_params(context, p);
+                if (SIXEL_FAILED(status)) {
+                    return status;
+                }
+                p++;
+                break;
+            case ';':
+                if (context->param < 0) {
+                    context->param = 0;
+                }
+                if (context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                context->param = 0;
+                p++;
+                break;
+            case 'q':
+                if (context->param >= 0 && context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                if (context->nparams > 0) {
+                    /* Pn1 */
+                    switch (context->params[0]) {
+                    case 0:
+                    case 1:
+                        context->attributed_pad = 2;
+                        break;
+                    case 2:
+                        context->attributed_pad = 5;
+                        break;
+                    case 3:
+                    case 4:
+                        context->attributed_pad = 4;
+                        break;
+                    case 5:
+                    case 6:
+                        context->attributed_pad = 3;
+                        break;
+                    case 7:
+                    case 8:
+                        context->attributed_pad = 2;
+                        break;
+                    case 9:
+                        context->attributed_pad = 1;
+                        break;
+                    default:
+                        context->attributed_pad = 2;
+                        break;
+                    }
+                }
+
+                if (context->nparams > 2) {
+                    /* Pn3 */
+                    if (context->params[2] == 0) {
+                        context->params[2] = 10;
+                    }
+                    context->attributed_pan = context->attributed_pan * context->params[2] / 10;
+                    context->attributed_pad = context->attributed_pad * context->params[2] / 10;
+                    if (context->attributed_pan <= 0) {
+                        context->attributed_pan = 1;
+                    }
+                    if (context->attributed_pad <= 0) {
+                        context->attributed_pad = 1;
+                    }
+                }
+                context->nparams = 0;
+                context->state = PS_DECSIXEL;
+                p++;
+                break;
+            default:
+                p++;
+                break;
+            }
+            break;
+
+        case PS_DECSIXEL:
+            switch (*p) {
+            case '\x1b':
+                context->state = PS_ESC;
+                p++;
+                break;
+            case '"':
+                context->param = 0;
+                context->nparams = 0;
+                context->state = PS_DECGRA;
+                p++;
+                break;
+            case '!':
+                context->param = 0;
+                context->nparams = 0;
+                context->state = PS_DECGRI;
+                p++;
+                break;
+            case '#':
+                context->param = 0;
+                context->nparams = 0;
+                context->state = PS_DECGCI;
+                p++;
+                break;
+            case '$':
+                /* DECGCR Graphics Carriage Return */
+                context->pos_x = 0;
+                p++;
+                break;
+            case '-':
+                /* DECGNL Graphics Next Line */
+                context->pos_x = 0;
+                context->pos_y += 6;
+                p++;
+                break;
+            default:
+                if (*p >= '?' && *p <= '~') {  /* sixel characters */
+
+                    sx = image->width;
+                    while (sx < context->pos_x + context->repeat_count) {
+                        sx *= 2;
+                    }
+
+                    sy = image->height;
+                    while (sy < context->pos_y + 6) {
+                        sy *= 2;
+                    }
+
+                    if (sx > image->width || sy > image->height) {
+                        status = image_buffer_resize(image, sx, sy, context->bgindex);
+                        if (SIXEL_FAILED(status)) {
+                            return status;
+                        }
+                    }
+
+                    if (context->color_index > image->ncolors) {
+                        image->ncolors = context->color_index;
+                    }
+
+                    if (context->pos_x < 0 || context->pos_y < 0) {
+                        status = SIXEL_BAD_INPUT;
+                        return status;
+                    }
+                    bits = *p - '?';
+
+                    if (bits == 0) {
+                        context->pos_x += context->repeat_count;
+                    } else {
+                        sixel_vertical_mask = 0x01;
+                        if (context->repeat_count <= 1) {
+                            for (i = 0; i < 6; i++) {
+                                if ((bits & sixel_vertical_mask) != 0) {
+                                    pos = (size_t)image->width * (size_t)(context->pos_y + i) + (size_t)context->pos_x;
+                                    image->data[pos] = context->color_index;
+                                    if (context->max_x < context->pos_x) {
+                                        context->max_x = context->pos_x;
+                                    }
+                                    if (context->max_y < (context->pos_y + i)) {
+                                        context->max_y = context->pos_y + i;
+                                    }
+                                }
+                                sixel_vertical_mask <<= 1;
+                            }
+                            context->pos_x += 1;
+                        } else {
+                            /* context->repeat_count > 1 */
+                            for (i = 0; i < 6; i++) {
+                                if ((bits & sixel_vertical_mask) != 0) {
+                                    c = sixel_vertical_mask << 1;
+                                    for (n = 1; (i + n) < 6; n++) {
+                                        if ((bits & c) == 0) {
+                                            break;
+                                        }
+                                        c <<= 1;
+                                    }
+                                    for (y = context->pos_y + i; y < context->pos_y + i + n; ++y) {
+                                        sixel_memset(image->data + (size_t)image->width * (size_t)y + (size_t)context->pos_x,
+                                               context->color_index,
+                                               (size_t)context->repeat_count);
+                                    }
+                                    if (context->max_x < (context->pos_x + context->repeat_count - 1)) {
+                                        context->max_x = context->pos_x + context->repeat_count - 1;
+                                    }
+                                    if (context->max_y < (context->pos_y + i + n - 1)) {
+                                        context->max_y = context->pos_y + i + n - 1;
+                                    }
+                                    i += (n - 1);
+                                    sixel_vertical_mask <<= (n - 1);
+                                }
+                                sixel_vertical_mask <<= 1;
+                            }
+                            context->pos_x += context->repeat_count;
+                        }
+                    }
+                    context->repeat_count = 1;
+                }
+                p++;
+                break;
+            }
+            break;
+
+        case PS_DECGRA:
+            /* DECGRA Set Raster Attributes " Pan; Pad; Ph; Pv */
+            switch (*p) {
+            case '\x1b':
+                context->state = PS_ESC;
+                p++;
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                status = safe_addition_for_params(context, p);
+                if (SIXEL_FAILED(status)) {
+                    return status;
+                }
+                p++;
+                break;
+            case ';':
+                if (context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                context->param = 0;
+                p++;
+                break;
+            default:
+                if (context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                if (context->nparams > 0) {
+                    context->attributed_pad = context->params[0];
+                }
+                if (context->nparams > 1) {
+                    context->attributed_pan = context->params[1];
+                }
+                if (context->nparams > 2 && context->params[2] > 0) {
+                    context->attributed_ph = context->params[2];
+                }
+                if (context->nparams > 3 && context->params[3] > 0) {
+                    context->attributed_pv = context->params[3];
+                }
+
+                if (context->attributed_pan <= 0) {
+                    context->attributed_pan = 1;
+                }
+                if (context->attributed_pad <= 0) {
+                    context->attributed_pad = 1;
+                }
+
+                if (image->width < context->attributed_ph ||
+                        image->height < context->attributed_pv) {
+                    sx = context->attributed_ph;
+                    if (image->width > context->attributed_ph) {
+                        sx = image->width;
+                    }
+
+                    sy = context->attributed_pv;
+                    if (image->height > context->attributed_pv) {
+                        sy = image->height;
+                    }
+
+                    status = image_buffer_resize(image, sx, sy, context->bgindex);
+                    if (SIXEL_FAILED(status)) {
+                        return status;
+                    }
+                }
+                context->state = PS_DECSIXEL;
+                context->param = 0;
+                context->nparams = 0;
+            }
+            break;
+
+        case PS_DECGRI:
+            /* DECGRI Graphics Repeat Introducer ! Pn Ch */
+            switch (*p) {
+            case '\x1b':
+                context->state = PS_ESC;
+                p++;
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                status = safe_addition_for_params(context, p);
+                if (SIXEL_FAILED(status)) {
+                    return status;
+                }
+                p++;
+                break;
+            default:
+                context->repeat_count = context->param;
+                if (context->repeat_count == 0) {
+                    context->repeat_count = 1;
+                }
+                if (context->repeat_count > 0xffff) {  /* check too huge number */
+                    status = SIXEL_BAD_INPUT;
+                    return status;
+                }
+                context->state = PS_DECSIXEL;
+                context->param = 0;
+                context->nparams = 0;
+                break;
+            }
+            break;
+
+        case PS_DECGCI:
+            /* DECGCI Graphics Color Introducer # Pc; Pu; Px; Py; Pz */
+            switch (*p) {
+            case '\x1b':
+                context->state = PS_ESC;
+                p++;
+                break;
+            case '0':
+            case '1':
+            case '2':
+            case '3':
+            case '4':
+            case '5':
+            case '6':
+            case '7':
+            case '8':
+            case '9':
+                status = safe_addition_for_params(context, p);
+                if (SIXEL_FAILED(status)) {
+                    return status;
+                }
+                p++;
+                break;
+            case ';':
+                if (context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                context->param = 0;
+                p++;
+                break;
+            default:
+                context->state = PS_DECSIXEL;
+                if (context->nparams < DECSIXEL_PARAMS_MAX) {
+                    context->params[context->nparams++] = context->param;
+                }
+                context->param = 0;
+
+                if (context->nparams > 0) {
+                    context->color_index = context->params[0];
+                    if (context->color_index < 0) {
+                        context->color_index = 0;
+                    } else if (context->color_index >= SIXEL_PALETTE_MAX) {
+                        context->color_index = SIXEL_PALETTE_MAX - 1;
+                    }
+                }
+
+                if (context->nparams > 4) {
+                    if (context->params[1] == 1) {
+                        /* HLS */
+                        if (context->params[2] > 360) {
+                            context->params[2] = 360;
+                        }
+                        if (context->params[3] > 100) {
+                            context->params[3] = 100;
+                        }
+                        if (context->params[4] > 100) {
+                            context->params[4] = 100;
+                        }
+                        image->palette[context->color_index]
+                            = hls_to_rgb(context->params[2], context->params[3], context->params[4]);
+                    } else if (context->params[1] == 2) {
+                        /* RGB */
+                        if (context->params[2] > 100) {
+                            context->params[2] = 100;
+                        }
+                        if (context->params[3] > 100) {
+                            context->params[3] = 100;
+                        }
+                        if (context->params[4] > 100) {
+                            context->params[4] = 100;
+                        }
+                        image->palette[context->color_index]
+                            = SIXEL_XRGB(context->params[2], context->params[3], context->params[4]);
+                    }
+                }
+                break;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+
+finalize:
+    if (++context->max_x < context->attributed_ph) {
+        context->max_x = context->attributed_ph;
+    }
+
+    if (++context->max_y < context->attributed_pv) {
+        context->max_y = context->attributed_pv;
+    }
+
+    if (image->width > context->max_x || image->height > context->max_y) {
+        status = image_buffer_resize(image, context->max_x, context->max_y, context->bgindex);
+        if (SIXEL_FAILED(status)) {
+            return status;
+        }
+    }
+
+    status = SIXEL_OK;
+    return status;
+}
+
+/* convert sixel data into indexed pixel bytes and palette data */
+SIXELSTATUS sixel_decode_raw(
+    unsigned char       /* in */  *p,           /* sixel bytes */
+    int                 /* in */  len,          /* size of sixel bytes */
+    unsigned char       /* out */ **pixels,     /* decoded pixels */
+    int                 /* out */ *pwidth,      /* image width */
+    int                 /* out */ *pheight,     /* image height */
+    unsigned char       /* out */ **palette,    /* ARGB palette */
+    int                 /* out */ *ncolors)     /* palette size (<= 256) */
+{
+    SIXELSTATUS status = SIXEL_FALSE;
+    parser_context_t context;
+    image_buffer_t image;
+    int n;
+
+    image.data = NULL;
+
+    /* parser context initialization */
+    status = parser_context_init(&context);
+    if (SIXEL_FAILED(status)) {
+        goto error;
+    }
+
+    /* buffer initialization */
+    status = image_buffer_init(&image, 1, 1, context.bgindex);
+    if (SIXEL_FAILED(status)) {
+        goto error;
+    }
+
+    status = sixel_decode_raw_impl(p, len, &image, &context);
+    if (SIXEL_FAILED(status)) {
+        goto error;
+    }
+
+    *ncolors = image.ncolors + 1;
+    int alloc_size = *ncolors;
+    if (alloc_size < SIXEL_PALETTE_MAX) {
+        /* memory access range should be 0 <= 255 */
+        alloc_size = SIXEL_PALETTE_MAX;
+    }
+    *palette = (unsigned char *)sixel_malloc((size_t)(alloc_size * 3));
+    if (palette == NULL) {
+        sixel_free(image.data);
+        status = SIXEL_BAD_ALLOCATION;
+        goto error;
+    }
+    for (n = 0; n < *ncolors; ++n) {
+        (*palette)[n * 3 + 0] = image.palette[n] >> 16 & 0xff;
+        (*palette)[n * 3 + 1] = image.palette[n] >> 8 & 0xff;
+        (*palette)[n * 3 + 2] = image.palette[n] & 0xff;
+    }
+
+    *pwidth = image.width;
+    *pheight = image.height;
+    *pixels = image.data;
+
+    status = SIXEL_OK;
+    return status;
+
+error:
+    sixel_free(image.data);
+    image.data = NULL;
+
+    return status;
+}

--- a/sixel/sixel.h
+++ b/sixel/sixel.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014-2020 Hayaki Saito
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef SIXEL_H
+#define SIXEL_H
+
+#define SIXEL_PALETTE_MAX          256
+#define SIXEL_WIDTH_LIMIT          1000000
+#define SIXEL_HEIGHT_LIMIT         1000000
+
+/* return value */
+typedef int SIXELSTATUS;
+#define SIXEL_OK                   0x0000                          /* succeeded */
+#define SIXEL_FALSE                0x1000                          /* failed */
+
+#define SIXEL_RUNTIME_ERROR        (SIXEL_FALSE         | 0x0100)  /* runtime error */
+#define SIXEL_BAD_INPUT            (SIXEL_RUNTIME_ERROR | 0x0003)  /* bad input detected */
+#define SIXEL_BAD_INTEGER_OVERFLOW (SIXEL_RUNTIME_ERROR | 0x0004)  /* integer overflow */
+#define SIXEL_BAD_ALLOCATION       (SIXEL_RUNTIME_ERROR | 0x0001)  /* malloc() failed */
+
+#define SIXEL_SUCCEEDED(status) (((status) & 0x1000) == 0)
+#define SIXEL_FAILED(status)    (((status) & 0x1000) != 0)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+SIXELSTATUS
+sixel_decode_raw(
+    unsigned char       /* in */  *p,           /* sixel bytes */
+    int                 /* in */  len,          /* size of sixel bytes */
+    unsigned char       /* out */ **pixels,     /* decoded pixels */
+    int                 /* out */ *pwidth,      /* image width */
+    int                 /* out */ *pheight,     /* image height */
+    unsigned char       /* out */ **palette,    /* ARGB palette */
+    int                 /* out */ *ncolors);    /* palette size (<= 256) */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* SIXEL_H */

--- a/sixel/sixel_api.h
+++ b/sixel/sixel_api.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2016 Hayaki Saito
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef SIXEL_API_H
+#define SIXEL_API_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void *sixel_malloc(size_t size);
+void sixel_free(void *ptr);
+
+void *sixel_memset(void *dest, int ch, size_t count);
+void *sixel_memcpy(void *dest, const void *src, size_t count);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SIXEL_API_H */


### PR DESCRIPTION
just synced to trunk and made a few changes.

everything works the same way as the normal flanterm, but user can now print sixels by passing the full string to ``term_write``

changes to the user api:
* function pointer ``_free`` passed to ``flanterm_fb_init`` no longer includes ``size_t size`` argument.
* ``ctx->deinit`` no longer takes a ``_free`` as an argument.
* if ``_malloc`` and ``_free`` are NULL, sixel support is disabled.