### PR TITLE
Parse unhandled CSI and OSC sequences correctly

### DIFF
--- a/src/flanterm.c
+++ b/src/flanterm.c
@@ -463,26 +463,37 @@ static void mode_toggle(struct flanterm_context *ctx, uint8_t c) {
     }
 }
 
-static void osc_parse(struct flanterm_context *ctx, uint8_t c) {
-    if (ctx->osc_escape && c == '\\') {
-        goto cleanup;
+static bool osc_parse(struct flanterm_context *ctx, uint8_t c) {
+    // ESC \ terminates an OSC sequence cleanly
+    // but if ESC is followed by non-\, report failure from osc_parse and
+    // try parsing the character as another escape code
+    if (ctx->osc_escape) {
+        if (c == '\\') {
+            ctx->osc = false;
+            ctx->osc_escape = false;
+            ctx->escape = false;
+            return true;
+        } else {
+            ctx->osc_escape = false;
+            ctx->osc = false;
+            // escape stays true here
+            return false;
+        }
     }
-
-    ctx->osc_escape = false;
-
     switch (c) {
         case 0x1b:
             ctx->osc_escape = true;
-            return;
+            break;
+        // BEL is the other terminator 
         case '\a':
+            ctx->osc_escape = false;
+            ctx->osc = false;
+            ctx->escape = false;
+            break;
         default:
             break;
     }
-
-cleanup:
-    ctx->osc_escape = false;
-    ctx->osc = false;
-    ctx->escape = false;
+    return true;
 }
 
 static void control_sequence_parse(struct flanterm_context *ctx, uint8_t c) {
@@ -817,8 +828,13 @@ static void escape_parse(struct flanterm_context *ctx, uint8_t c) {
     ctx->escape_offset++;
 
     if (ctx->osc == true) {
-        osc_parse(ctx, c);
-        return;
+        // ESC \ is one of the two possible terminators of OSC sequences,
+        // so osc_parse consumes ESC.
+        // If it is then followed by \ it cleans correctly,
+        // otherwise it returns false, and it tries parsing it as another escape sequence
+        if (osc_parse(ctx, c)) {
+            return;
+        }
     }
 
     if (ctx->control_sequence == true) {

--- a/src/flanterm.c
+++ b/src/flanterm.c
@@ -566,6 +566,9 @@ static void control_sequence_parse(struct flanterm_context *ctx, uint8_t c) {
     }
 
     switch (c) {
+        // Got ESC in the middle of an escape sequence, start a new one
+        case 0x1B:
+            return;
         case 'F':
             x = 0;
             // FALLTHRU

--- a/src/flanterm_private.h
+++ b/src/flanterm_private.h
@@ -58,6 +58,7 @@ struct flanterm_context {
     bool reverse_video;
     bool dec_private;
     bool insert_mode;
+    bool csi_unhandled;
     uint64_t code_point;
     size_t unicode_remaining;
     uint8_t g_select;


### PR DESCRIPTION
`fish` sends various escape sequences not supported by `TERM=linux`.
Ignoring them properly instead of eagerly exiting escape mode fixes the default prompt.