### PR TITLE
Add context pointer to allocator functions

### DIFF
--- a/BACKEND_FB.md
+++ b/BACKEND_FB.md
@@ -19,8 +19,9 @@ Add `flanterm_backends/fb.c` to the build and include
 
 ```c
 struct flanterm_context *flanterm_fb_init(
-    void *(*_malloc)(size_t),
-    void (*_free)(void *, size_t),
+    void *(*_malloc)(void *, size_t),
+    void (*_free)(void *, void *, size_t),
+    void *alloc_ctx,
     uint32_t *framebuffer, size_t width, size_t height, size_t pitch,
     uint8_t red_mask_size, uint8_t red_mask_shift,
     uint8_t green_mask_size, uint8_t green_mask_shift,
@@ -42,6 +43,7 @@ invalid framebuffer geometry, unsupported pixel format, etc.).
 | Parameter | Meaning |
 | --- | --- |
 | `_malloc`, `_free` | Client allocator. If both are `NULL`, the built-in bump allocator is used (only one live instance at a time; see [below](#allocator-and-the-built-in-bump-allocator)). |
+| `alloc_ctx` | Passed as first argument to `_malloc` and `_free` |
 | `framebuffer` | The 32-bit framebuffer, writable as `uint32_t *`. |
 | `width`, `height` | Physical framebuffer dimensions in pixels. Swapped internally for `ROTATE_90`/`ROTATE_270` (see [Rotation](#rotation)). |
 | `pitch` | Physical scanline stride in bytes. Must be a multiple of `sizeof(uint32_t)` and at least `width * 4`. |
@@ -104,6 +106,8 @@ mode:
 With a custom allocator, `_malloc` is used for every allocation and the
 paired `_free` runs when freeing. `_free` receives the allocation
 size as its second argument.
+
+Both `_malloc` and `_free` receive the `alloc_ctx` as first argument.
 
 ## Flush callback
 

--- a/FRONTEND.md
+++ b/FRONTEND.md
@@ -43,10 +43,10 @@ Redraws from the cell grid, bypassing the dirty-queue. Appropriate after the
 backing surface has been clobbered.
 
 ```c
-void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, size_t));
+void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, void *, size_t), void *alloc_ctx);
 ```
-Tears down the context. `_free` must match the allocator passed at init or
-be `NULL` if applicable.
+Tears down the context. `_free` and `alloc_ctx` must match the allocator passed
+at init or be `NULL` if applicable.
 
 ```c
 void flanterm_get_dimensions(struct flanterm_context *ctx, size_t *cols, size_t *rows);

--- a/src/flanterm.c
+++ b/src/flanterm.c
@@ -2133,8 +2133,8 @@ void flanterm_full_refresh(struct flanterm_context *ctx) {
     ctx->full_refresh(ctx);
 }
 
-void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, size_t)) {
-    ctx->deinit(ctx, _free);
+void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *, void *, size_t), void *alloc_ctx) {
+    ctx->deinit(ctx, _free, alloc_ctx);
 }
 
 void flanterm_get_dimensions(struct flanterm_context *ctx, size_t *cols, size_t *rows) {

--- a/src/flanterm.h
+++ b/src/flanterm.h
@@ -59,7 +59,7 @@ struct flanterm_context;
 void flanterm_write(struct flanterm_context *ctx, const char *buf, size_t count);
 void flanterm_flush(struct flanterm_context *ctx);
 void flanterm_full_refresh(struct flanterm_context *ctx);
-void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *ptr, size_t size));
+void flanterm_deinit(struct flanterm_context *ctx, void (*_free)(void *ctx, void *ptr, size_t size), void *alloc_ctx);
 
 void flanterm_get_dimensions(struct flanterm_context *ctx, size_t *cols, size_t *rows);
 void flanterm_set_autoflush(struct flanterm_context *ctx, bool state);

--- a/src/flanterm_backends/fb.c
+++ b/src/flanterm_backends/fb.c
@@ -86,7 +86,9 @@ static uint8_t bump_alloc_pool[FLANTERM_FB_BUMP_ALLOC_POOL_SIZE];
 static size_t bump_alloc_ptr = 0;
 static bool bump_alloc_base_offset_added = false;
 
-static void *bump_alloc(size_t s) {
+static void *bump_alloc(void *ctx, size_t s) {
+    (void)ctx;
+
     if (!bump_alloc_base_offset_added) {
         if ((uintptr_t)bump_alloc_pool & 0xf) {
             bump_alloc_ptr += 0x10 - ((uintptr_t)bump_alloc_pool & 0xf);
@@ -1174,7 +1176,7 @@ static void flanterm_fb_full_refresh(struct flanterm_context *_ctx) {
     }
 }
 
-static void flanterm_fb_deinit(struct flanterm_context *_ctx, void (*_free)(void *, size_t)) {
+static void flanterm_fb_deinit(struct flanterm_context *_ctx, void (*_free)(void *, void *, size_t), void *alloc_ctx) {
     struct flanterm_fb_context *ctx = (void *)_ctx;
 
     if (_free == NULL) {
@@ -1188,22 +1190,23 @@ static void flanterm_fb_deinit(struct flanterm_context *_ctx, void (*_free)(void
         return;
     }
 
-    _free(ctx->font_bits, ctx->font_bits_size);
-    _free(ctx->font_bool, ctx->font_bool_size);
-    _free(ctx->grid, ctx->grid_size);
-    _free(ctx->queue, ctx->queue_size);
-    _free(ctx->map, ctx->map_size);
+    _free(alloc_ctx, ctx->font_bits, ctx->font_bits_size);
+    _free(alloc_ctx, ctx->font_bool, ctx->font_bool_size);
+    _free(alloc_ctx, ctx->grid, ctx->grid_size);
+    _free(alloc_ctx, ctx->queue, ctx->queue_size);
+    _free(alloc_ctx, ctx->map, ctx->map_size);
 
     if (ctx->canvas != NULL) {
-        _free(ctx->canvas, ctx->canvas_size);
+        _free(alloc_ctx, ctx->canvas, ctx->canvas_size);
     }
 
-    _free(ctx, sizeof(struct flanterm_fb_context));
+    _free(alloc_ctx, ctx, sizeof(struct flanterm_fb_context));
 }
 
 struct flanterm_context *flanterm_fb_init(
-    void *(*_malloc)(size_t),
-    void (*_free)(void *, size_t),
+    void *(*_malloc)(void *, size_t),
+    void (*_free)(void *, void *, size_t),
+    void *alloc_ctx,
     uint32_t *framebuffer, size_t width, size_t height, size_t pitch,
     uint8_t red_mask_size, uint8_t red_mask_shift,
     uint8_t green_mask_size, uint8_t green_mask_shift,
@@ -1308,7 +1311,7 @@ struct flanterm_context *flanterm_fb_init(
     }
 
     struct flanterm_fb_context *ctx = NULL;
-    ctx = _malloc(sizeof(struct flanterm_fb_context));
+    ctx = _malloc(alloc_ctx, sizeof(struct flanterm_fb_context));
     if (ctx == NULL) {
         goto fail;
     }
@@ -1402,7 +1405,7 @@ struct flanterm_context *flanterm_fb_init(
         if (mul_size_overflow(font_height, (size_t)FLANTERM_FB_FONT_GLYPHS, &ctx->font_bits_size)) {
             goto fail;
         }
-        ctx->font_bits = _malloc(ctx->font_bits_size);
+        ctx->font_bits = _malloc(alloc_ctx, ctx->font_bits_size);
         if (ctx->font_bits == NULL) {
             goto fail;
         }
@@ -1412,7 +1415,7 @@ struct flanterm_context *flanterm_fb_init(
         ctx->font_height = font_height = 16;
         ctx->font_bits_size = FONT_BYTES;
         font_spacing = 1;
-        ctx->font_bits = _malloc(ctx->font_bits_size);
+        ctx->font_bits = _malloc(alloc_ctx, ctx->font_bits_size);
         if (ctx->font_bits == NULL) {
             goto fail;
         }
@@ -1431,7 +1434,7 @@ struct flanterm_context *flanterm_fb_init(
         mul_size_overflow(ctx->font_bool_size, sizeof(bool), &ctx->font_bool_size)) {
         goto fail;
     }
-    ctx->font_bool = _malloc(ctx->font_bool_size);
+    ctx->font_bool = _malloc(alloc_ctx, ctx->font_bool_size);
     if (ctx->font_bool == NULL) {
         goto fail;
     }
@@ -1495,7 +1498,7 @@ struct flanterm_context *flanterm_fb_init(
         mul_size_overflow(ctx->grid_size, sizeof(struct flanterm_fb_char), &ctx->grid_size)) {
         goto fail;
     }
-    ctx->grid = _malloc(ctx->grid_size);
+    ctx->grid = _malloc(alloc_ctx, ctx->grid_size);
     if (ctx->grid == NULL) {
         goto fail;
     }
@@ -1511,7 +1514,7 @@ struct flanterm_context *flanterm_fb_init(
         mul_size_overflow(ctx->queue_size, sizeof(struct flanterm_fb_queue_item), &ctx->queue_size)) {
         goto fail;
     }
-    ctx->queue = _malloc(ctx->queue_size);
+    ctx->queue = _malloc(alloc_ctx, ctx->queue_size);
     if (ctx->queue == NULL) {
         goto fail;
     }
@@ -1522,7 +1525,7 @@ struct flanterm_context *flanterm_fb_init(
         mul_size_overflow(ctx->map_size, sizeof(struct flanterm_fb_queue_item *), &ctx->map_size)) {
         goto fail;
     }
-    ctx->map = _malloc(ctx->map_size);
+    ctx->map = _malloc(alloc_ctx, ctx->map_size);
     if (ctx->map == NULL) {
         goto fail;
     }
@@ -1533,7 +1536,7 @@ struct flanterm_context *flanterm_fb_init(
             mul_size_overflow(ctx->canvas_size, sizeof(uint32_t), &ctx->canvas_size)) {
             goto fail;
         }
-        ctx->canvas = _malloc(ctx->canvas_size);
+        ctx->canvas = _malloc(alloc_ctx, ctx->canvas_size);
         if (ctx->canvas == NULL) {
             goto fail;
         }
@@ -1609,25 +1612,25 @@ fail:
     }
 
     if (ctx->canvas != NULL) {
-        _free(ctx->canvas, ctx->canvas_size);
+        _free(alloc_ctx, ctx->canvas, ctx->canvas_size);
     }
     if (ctx->map != NULL) {
-        _free(ctx->map, ctx->map_size);
+        _free(alloc_ctx, ctx->map, ctx->map_size);
     }
     if (ctx->queue != NULL) {
-        _free(ctx->queue, ctx->queue_size);
+        _free(alloc_ctx, ctx->queue, ctx->queue_size);
     }
     if (ctx->grid != NULL) {
-        _free(ctx->grid, ctx->grid_size);
+        _free(alloc_ctx, ctx->grid, ctx->grid_size);
     }
     if (ctx->font_bool != NULL) {
-        _free(ctx->font_bool, ctx->font_bool_size);
+        _free(alloc_ctx, ctx->font_bool, ctx->font_bool_size);
     }
     if (ctx->font_bits != NULL) {
-        _free(ctx->font_bits, ctx->font_bits_size);
+        _free(alloc_ctx, ctx->font_bits, ctx->font_bits_size);
     }
     if (ctx != NULL) {
-        _free(ctx, sizeof(struct flanterm_fb_context));
+        _free(alloc_ctx, ctx, sizeof(struct flanterm_fb_context));
     }
 
     return NULL;

--- a/src/flanterm_backends/fb.h
+++ b/src/flanterm_backends/fb.h
@@ -51,8 +51,9 @@ extern "C" {
 
 struct flanterm_context *flanterm_fb_init(
     /* If _malloc and _free are nulled, use the bump allocated instance (1 use only). */
-    void *(*_malloc)(size_t size),
-    void (*_free)(void *ptr, size_t size),
+    void *(*_malloc)(void *ctx, size_t size),
+    void (*_free)(void *ctx, void *ptr, size_t size),
+    void *alloc_ctx,
     uint32_t *framebuffer, size_t width, size_t height, size_t pitch,
     uint8_t red_mask_size, uint8_t red_mask_shift,
     uint8_t green_mask_size, uint8_t green_mask_shift,

--- a/src/flanterm_private.h
+++ b/src/flanterm_private.h
@@ -116,7 +116,7 @@ struct flanterm_context {
     void (*restore_state)(struct flanterm_context *);
     void (*double_buffer_flush)(struct flanterm_context *);
     void (*full_refresh)(struct flanterm_context *);
-    void (*deinit)(struct flanterm_context *, void (*)(void *, size_t));
+    void (*deinit)(struct flanterm_context *, void (*)(void *, void *, size_t), void *);
 
     /* to be set by client */
 


### PR DESCRIPTION
## Context

In my kernel, I have a VTable-like interface for allocators:

```c
typedef struct allocator allocator;
struct allocator {
  void *(*allocate)  (void *udata, usize sz);
  void *(*reallocate)(void *udata, void *ptr, usize oldsz, usize newsz);
  void  (*deallocate)(void *udata, void *ptr, usize sz);

  void *udata;
};
```

This allows me to implement multiple kinds of allocators (static size bump, scratch, slab, ...) and even nest them. The crucial point is the `udata` pointer that holds the allocator's state.

In flanterm, I can give an allocation and deallocation function, but they do not accept an equivalent to the `udata` pointer. This means I have to manage the allocator's state elsewhere (in static globals would be a code smell and a bug waiting to happen).

## Changes

This PR adds an `alloc_ctx` pointer to the fb backend and pass it to the _malloc and _free functions.

To mimic previous usage, you can just pass `NULL` and ignore the parameter.

> **NB:** This is a breaking change as it modifies the public API.